### PR TITLE
[feat] 게시물 삭제 기능+키보드 내림

### DIFF
--- a/Sukbakji.xcodeproj/project.pbxproj
+++ b/Sukbakji.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		7B3E3D2B2C5423B3002D6A43 /* ScrappedBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3E3D2A2C5423B3002D6A43 /* ScrappedBoardViewController.swift */; };
 		7B3E3D2D2C5423D6002D6A43 /* CommentedBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3E3D2C2C5423D6002D6A43 /* CommentedBoardViewController.swift */; };
 		7B3E3D2F2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3E3D2E2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift */; };
+		7B962D4B2DA902F9004175E0 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B962D4A2DA902F9004175E0 /* UIApplication+.swift */; };
 		7BC4E7842D8AC39300963B61 /* SavedBoardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC4E7832D8AC39300963B61 /* SavedBoardResponse.swift */; };
 		7BC4E7862D8ACF3D00963B61 /* LatestQnAModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC4E7852D8ACF3D00963B61 /* LatestQnAModel.swift */; };
 		7BD758A12DA11E0100E107B2 /* BoardEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD758A02DA11E0100E107B2 /* BoardEditViewController.swift */; };
@@ -327,6 +328,7 @@
 		7B3E3D2A2C5423B3002D6A43 /* ScrappedBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrappedBoardViewController.swift; sourceTree = "<group>"; };
 		7B3E3D2C2C5423D6002D6A43 /* CommentedBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedBoardViewController.swift; sourceTree = "<group>"; };
 		7B3E3D2E2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmploymentReviewWriteBoardViewController.swift; sourceTree = "<group>"; };
+		7B962D4A2DA902F9004175E0 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		7BC4E7832D8AC39300963B61 /* SavedBoardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBoardResponse.swift; sourceTree = "<group>"; };
 		7BC4E7852D8ACF3D00963B61 /* LatestQnAModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestQnAModel.swift; sourceTree = "<group>"; };
 		7BD758A02DA11E0100E107B2 /* BoardEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditViewController.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				91EB930E2D81547D00A6BBB0 /* UIFont+.swift */,
 				C70523F02D775442009AED8C /* UIView+.swift */,
 				C74680742D91352B00A6091E /* DateUtils+.swift */,
+				7B962D4A2DA902F9004175E0 /* UIApplication+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1648,6 +1651,7 @@
 				7B3E3D2B2C5423B3002D6A43 /* ScrappedBoardViewController.swift in Sources */,
 				C734BD582D66DE1700AE81E9 /* EdifInfoView.swift in Sources */,
 				7B1C535A2C69D85800C66D0D /* DirectoryFavoriteLabModel.swift in Sources */,
+				7B962D4B2DA902F9004175E0 /* UIApplication+.swift in Sources */,
 				C70DB2812C633CDB00D6014B /* ChattingViewController.swift in Sources */,
 				C74A15942D5A477000A1698B /* FavoriteBoard.swift in Sources */,
 				91D413432D827A4900020CEC /* EmailSignupView.swift in Sources */,

--- a/Sukbakji.xcodeproj/project.pbxproj
+++ b/Sukbakji.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		7B3E3D2D2C5423D6002D6A43 /* CommentedBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3E3D2C2C5423D6002D6A43 /* CommentedBoardViewController.swift */; };
 		7B3E3D2F2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3E3D2E2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift */; };
 		7B962D4B2DA902F9004175E0 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B962D4A2DA902F9004175E0 /* UIApplication+.swift */; };
+		7B962D4D2DA90AD7004175E0 /* BoardDeleteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B962D4C2DA90AD7004175E0 /* BoardDeleteModel.swift */; };
 		7BC4E7842D8AC39300963B61 /* SavedBoardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC4E7832D8AC39300963B61 /* SavedBoardResponse.swift */; };
 		7BC4E7862D8ACF3D00963B61 /* LatestQnAModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC4E7852D8ACF3D00963B61 /* LatestQnAModel.swift */; };
 		7BD758A12DA11E0100E107B2 /* BoardEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD758A02DA11E0100E107B2 /* BoardEditViewController.swift */; };
@@ -329,6 +330,7 @@
 		7B3E3D2C2C5423D6002D6A43 /* CommentedBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedBoardViewController.swift; sourceTree = "<group>"; };
 		7B3E3D2E2C542862002D6A43 /* EmploymentReviewWriteBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmploymentReviewWriteBoardViewController.swift; sourceTree = "<group>"; };
 		7B962D4A2DA902F9004175E0 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
+		7B962D4C2DA90AD7004175E0 /* BoardDeleteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDeleteModel.swift; sourceTree = "<group>"; };
 		7BC4E7832D8AC39300963B61 /* SavedBoardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBoardResponse.swift; sourceTree = "<group>"; };
 		7BC4E7852D8ACF3D00963B61 /* LatestQnAModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestQnAModel.swift; sourceTree = "<group>"; };
 		7BD758A02DA11E0100E107B2 /* BoardEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditViewController.swift; sourceTree = "<group>"; };
@@ -771,6 +773,7 @@
 				7B3933EE2D9FF147009EFC55 /* CurrentUserResponse.swift */,
 				7B3933F22D9FFB39009EFC55 /* CommentUpdateModel.swift */,
 				7B3933F62DA01681009EFC55 /* BoardUpdateModel.swift */,
+				7B962D4C2DA90AD7004175E0 /* BoardDeleteModel.swift */,
 			);
 			path = BoardModel;
 			sourceTree = "<group>";
@@ -1619,6 +1622,7 @@
 				C71AE9BE2CFB60590098FD2A /* FavoriteLabCollectionViewCell.swift in Sources */,
 				91FEEB892D71A02800D0502D /* SmsRequest.swift in Sources */,
 				C7C434EC2C5DF14E00BFB2D2 /* EditProfileViewController.swift in Sources */,
+				7B962D4D2DA90AD7004175E0 /* BoardDeleteModel.swift in Sources */,
 				C7B7A16A2D00360500D5CE14 /* UIButton+.swift in Sources */,
 				417AADCD2C673E28002080E0 /* AuthRequest.swift in Sources */,
 				C7EA8CB12D689AB600B25FBC /* CalendarViewModel.swift in Sources */,

--- a/Sukbakji/DesignSystem/Extensions/UIApplication+.swift
+++ b/Sukbakji/DesignSystem/Extensions/UIApplication+.swift
@@ -1,0 +1,25 @@
+//
+//  UIApplication+.swift
+//  Sukbakji
+//
+//  Created by KKM on 4/11/25.
+//
+
+import Foundation
+import SwiftUI
+
+extension UIApplication {
+    func hideKeyboard() {
+        guard let window = windows.first else { return }
+        let tapRecognizer = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+        tapRecognizer.cancelsTouchesInView = false
+        tapRecognizer.delegate = self
+        window.addGestureRecognizer(tapRecognizer)
+    }
+}
+
+extension UIApplication: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
+}

--- a/Sukbakji/PresentationLayer/Sources/Board/BoardEditViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/BoardEditViewController.swift
@@ -93,6 +93,7 @@ struct BoardEditViewController: View {
             titleText = originalTitle
             postText = originalContent
         }
+        .onAppear(perform: UIApplication.shared.hideKeyboard)
     }
 
     func updatePost() {

--- a/Sukbakji/PresentationLayer/Sources/Board/BoardModel/BoardDeleteModel.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/BoardModel/BoardDeleteModel.swift
@@ -1,0 +1,14 @@
+//
+//  BoardDeleteModel.swift
+//  Sukbakji
+//
+//  Created by KKM on 4/11/25.
+//
+
+import Foundation
+
+struct BoardDeletePostResponseModel: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+}

--- a/Sukbakji/PresentationLayer/Sources/Board/BoardWriteViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/BoardWriteViewController.swift
@@ -119,18 +119,10 @@ struct BoardWriteViewController: View {
             }
         }
         .navigationBarBackButtonHidden()
+        .onAppear(perform: UIApplication.shared.hideKeyboard)
     }
 
     func BoardWriteApi() {
-//        guard let accessTokenData = KeychainHelper.standard.read(service: "access-token", account: "user"),
-//              let accessToken = String(data: accessTokenData, encoding: .utf8) else {
-//            print("토큰이 없습니다.")
-//            return
-//        }
-//        guard let accessToken: String = KeychainHelper.standard.read(service: "access-token", account: "user", type: String.self) else {
-//            print("토큰이 없습니다.")
-//            return
-//        }
         
         let menu = selectedCategory ?? "박사"
         let boardName = selectedOptionIndex ?? "질문 게시판"

--- a/Sukbakji/PresentationLayer/Sources/Board/Main/DummyBoardDetail.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/Main/DummyBoardDetail.swift
@@ -270,6 +270,7 @@ struct DummyBoardDetail: View {
                 }
             }
         }
+        .onAppear(perform: UIApplication.shared.hideKeyboard)
     }
 
     // 댓글 작성 함수


### PR DESCRIPTION
# 📙 작업 내역
## 게시물 삭제 기능 구현 및 게시물 작성, 수정, 댓글 작성 시 키보드를 내릴 수 있습니다.
- Extension/UIApplication+ 에 hideKeyboard() 함수 작성 후 .onAppear(form: UIApplication.shared.hideKeyboard)를 통해 해당 뷰에서 키보드 외 영역을 터치하면 키보드가 내려갑니다.

## 기타
- close #259 
