### PR TITLE
[fix] 커스텀 탭바 적용 후 게시판, 디렉토리 UI 묻히는 문제 해결

### DIFF
--- a/Sukbakji/PresentationLayer/Sources/Board/Admission/BoardAdmissionViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/Admission/BoardAdmissionViewController.swift
@@ -92,7 +92,6 @@ struct BoardAdmissionViewController: View {
         .overlay(
             overlayButton(selectedButton: selectedButton)
                 .padding(.trailing, 24)
-                .padding(.bottom, 48)
             ,alignment: .bottomTrailing
         )
         .navigationBarHidden(true)

--- a/Sukbakji/PresentationLayer/Sources/Board/BoardViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/BoardViewController.swift
@@ -53,6 +53,7 @@ struct BoardViewController: View {
                     FreeView().tag("자유")
                 }
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                .edgesIgnoringSafeArea(.bottom)
             }
         }
         .navigationBarHidden(true)

--- a/Sukbakji/PresentationLayer/Sources/Board/Doctoral/BoardDoctoralViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/Doctoral/BoardDoctoralViewController.swift
@@ -82,7 +82,6 @@ struct BoardDoctoralViewController: View {
         .overlay(
             overlayButton(selectedButton: selectedButton)
                 .padding(.trailing, 24)
-                .padding(.bottom, 48)
             ,alignment: .bottomTrailing
         )
         .navigationBarHidden(true)

--- a/Sukbakji/PresentationLayer/Sources/Board/Main/BoardQnAViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/Main/BoardQnAViewController.swift
@@ -104,7 +104,6 @@ struct BoardQnAViewController: View {
                     .overlay(
                         overlayButton(selectedButton: "질문 게시판")
                             .padding(.trailing, 24) // 오른쪽 여백
-                            .padding(.bottom, 48) // 아래 여백
                         , alignment: .bottomTrailing // 오른쪽 아래에 위치
                     )
                 }
@@ -177,18 +176,21 @@ struct BoardQnAViewController: View {
                 if showAnonymousMessage {
                     VStack {
                         Spacer()
-                        Text("익명으로 함께 소통해 보세요!")
-                            .font(.system(size: 12, weight: .medium))
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 11)
-                            .background(Color(red: 1, green: 0.34, blue: 0.08))
-                            .foregroundColor(Constants.White)
-                            .cornerRadius(6)
+                        HStack {
+                            Spacer()
+                            
+                            Text("익명으로 함께 소통해 보세요!")
+                                .font(.system(size: 12, weight: .medium))
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 11)
+                                .background(Color(red: 1, green: 0.34, blue: 0.08))
+                                .foregroundColor(Constants.White)
+                                .cornerRadius(6)
+                        }
+                        .padding(.trailing, 24)
 
-                        Spacer().frame(height: 59)
+                        Spacer().frame(height: 65)
                     }
-                    .padding(.bottom, 55)
-                    .padding(.leading, 180)
                     .transition(.opacity)
                 }
             }

--- a/Sukbakji/PresentationLayer/Sources/Board/Master/BoardMasterViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Board/Master/BoardMasterViewController.swift
@@ -96,7 +96,6 @@ struct BoardMasterViewController: View {
         .overlay(
             overlayButton(selectedButton: selectedButton)
                 .padding(.trailing, 24)
-                .padding(.bottom, 48)
             ,alignment: .bottomTrailing
         )
         .navigationBarHidden(true)

--- a/Sukbakji/PresentationLayer/Sources/Directory/LabDetailReviewViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Directory/LabDetailReviewViewController.swift
@@ -157,8 +157,7 @@ struct LabDetailReviewViewController: View {
                 departmentName: departmentName,
                 professorName: professorName
             )
-            .padding(.trailing, 24)
-            .padding(.bottom, 48),
+            .padding(.trailing, 24),
             alignment: .bottomTrailing
         )
     }

--- a/Sukbakji/PresentationLayer/Sources/Directory/LabDetailViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Directory/LabDetailViewController.swift
@@ -102,6 +102,7 @@ struct LabDetailViewController: View {
                     .padding()
             }
         }
+        .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden()
         .onAppear {
             fetchLabDetail()

--- a/Sukbakji/PresentationLayer/Sources/Main/MainTabViewController.swift
+++ b/Sukbakji/PresentationLayer/Sources/Main/MainTabViewController.swift
@@ -149,7 +149,9 @@ class MainTabViewController: UITabBarController, UITabBarControllerDelegate {
         let swiftUIDirectoryView = DirectoryMainViewController()
         
         let boardVC = UIHostingController(rootView: swiftUIBoardView)
+        boardVC.additionalSafeAreaInsets.bottom = 92
         let directoryVC = UIHostingController(rootView: swiftUIDirectoryView)
+        directoryVC.additionalSafeAreaInsets.bottom = 92
         
         let navigationHome = UINavigationController(rootViewController: homeVC)
         let navigationCalendar = UINavigationController(rootViewController: calendarVC)


### PR DESCRIPTION
# 📙 작업 내역
## 게시판, 디렉토리 탭바 UI 수정
- MainTabBarViewController코드에서 게시판, 디렉토리 VC 하단 safe area 영역을 강제로 92pt만큼 더 추가
- 해당 코드에 따른 게시판, 디렉토리 세부 화면들 레이아웃 조정(.edgesIgnoringSafeArea(.bottom) 코드 추가 및 오버레이버튼(글쓰기, 연구실 후기작성) 의 bottom 여백 삭제)

## 기타
- close #267 
- ⚠️ 앱 업데이트 시 게시판, 디렉토리 화면에서 다른 VC로 넘어갈 때 문제가 생기는 것 같습니다. 반드시 앱 삭제 후 재설치 해야 해당 오류 해결됩니다.

### 참고 영상
![Simulator Screen Recording - iPhone 16 Pro - 2025-04-14 at 16 20 32](https://github.com/user-attachments/assets/11698224-3e8c-4eef-ab0c-d103f169752c)

